### PR TITLE
Database repositories

### DIFF
--- a/TripScanner/src/main/java/com/tripscanner/TripScanner/repository/DestinationRepository.java
+++ b/TripScanner/src/main/java/com/tripscanner/TripScanner/repository/DestinationRepository.java
@@ -1,0 +1,11 @@
+package com.tripscanner.TripScanner.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.tripscanner.TripScanner.model.Destination;
+
+public interface DestinationRepository extends JpaRepository<Destination, Long> {
+
+    Optional<Destination> findByName(String name);
+
+}

--- a/TripScanner/src/main/java/com/tripscanner/TripScanner/repository/ItineraryRepository.java
+++ b/TripScanner/src/main/java/com/tripscanner/TripScanner/repository/ItineraryRepository.java
@@ -1,0 +1,11 @@
+package com.tripscanner.TripScanner.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.tripscanner.TripScanner.model.Itinerary;
+
+public interface ItineraryRepository extends JpaRepository<Itinerary, Long> {
+
+    Optional<Itinerary> findByName(String name);
+
+}

--- a/TripScanner/src/main/java/com/tripscanner/TripScanner/repository/PlaceRepository.java
+++ b/TripScanner/src/main/java/com/tripscanner/TripScanner/repository/PlaceRepository.java
@@ -1,0 +1,11 @@
+package com.tripscanner.TripScanner.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.tripscanner.TripScanner.model.Place;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+    Optional<Place> findByName(String name);
+
+}

--- a/TripScanner/src/main/java/com/tripscanner/TripScanner/repository/ReviewRepository.java
+++ b/TripScanner/src/main/java/com/tripscanner/TripScanner/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.tripscanner.TripScanner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.tripscanner.TripScanner.model.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+}

--- a/TripScanner/src/main/java/com/tripscanner/TripScanner/repository/UserRepository.java
+++ b/TripScanner/src/main/java/com/tripscanner/TripScanner/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.tripscanner.TripScanner.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.tripscanner.TripScanner.model.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByEmail(String email);
+
+}


### PR DESCRIPTION
Added database repositories extending **JPA Repository** from Spring and using models previously implemented on dev branch. 
As for now, **reviews** can only be found by _id_; **destinations**, **places** and **itineraries** by _id_ and _name_; and **users** by _id_, _username_, and _email_. 
Merging closes #18 . 